### PR TITLE
Fix/possible stackoverflow

### DIFF
--- a/ExploringSpansAndPipelines.Core.Tests/ExploringSpansAndPipelines.Core.Tests.csproj
+++ b/ExploringSpansAndPipelines.Core.Tests/ExploringSpansAndPipelines.Core.Tests.csproj
@@ -16,6 +16,9 @@
     </ItemGroup>
 
     <ItemGroup>
+      <None Update="Assets\really-long-line.txt">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
       <None Update="Assets\TestData.psv">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>

--- a/ExploringSpansAndPipelines.Core.Tests/FileParserSpansAndPipesTests/WhenParsingValidFileWithLongLine.cs
+++ b/ExploringSpansAndPipelines.Core.Tests/FileParserSpansAndPipesTests/WhenParsingValidFileWithLongLine.cs
@@ -38,19 +38,17 @@ namespace ExploringSpansAndIOPipelines.Core.Tests.FileParserSpansAndPipesTests
         }
 
         [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
         public async Task ShouldReturnVideogames()
         {
             // Arrange
             var fileParserSpansAndPipes = new FileParserSpansAndPipelines();
 
-            // Act
-            var videogames = await fileParserSpansAndPipes.Parse(_file);
-
-            // Assert
-            CollectionAssert.AreEqual(_expected, videogames, new RecursiveComparer());
+            // Act and expect an exception
+            await fileParserSpansAndPipes.Parse(_file);
         }
 
-        private Videogame[] CreateExpected(string longLine) => new[]
+        private static Videogame[] CreateExpected(string longLine) => new[]
         {
             new Videogame
             {
@@ -72,7 +70,7 @@ namespace ExploringSpansAndIOPipelines.Core.Tests.FileParserSpansAndPipesTests
             },
         };
 
-        private async Task CreateFile(string file, IEnumerable<Videogame> videogames)
+        private static async Task CreateFile(string file, IEnumerable<Videogame> videogames)
         {
             var content = new StringBuilder();
             foreach (var videogame in videogames)
@@ -83,7 +81,7 @@ namespace ExploringSpansAndIOPipelines.Core.Tests.FileParserSpansAndPipesTests
             await File.WriteAllTextAsync(file, content.ToString());
         }
 
-        private void DeleteFile(string file)
+        private static void DeleteFile(string file)
         {
             if (File.Exists(file))
             {

--- a/ExploringSpansAndPipelines.Core.Tests/FileParserSpansAndPipesTests/WhenParsingValidFileWithLongLine.cs
+++ b/ExploringSpansAndPipelines.Core.Tests/FileParserSpansAndPipesTests/WhenParsingValidFileWithLongLine.cs
@@ -1,0 +1,94 @@
+﻿using ExploringSpansAndIOPipelines.Core.Models;
+using ExploringSpansAndIOPipelines.Core.Parsers;
+using ExploringSpansAndIOPipelines.Core.Tests.Comparers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ExploringSpansAndIOPipelines.Core.Tests.FileParserSpansAndPipesTests
+{
+    [TestClass]
+    public class WhenParsingValidFileWithLongLine
+    {
+        private const string TempPsvName = "temp.psv";
+
+        private string _file;
+        private Videogame[] _expected;
+
+        [TestInitialize]
+        public async Task Setup()
+        {
+            var current = Directory.GetCurrentDirectory();
+            var longLineFile = Path.Combine(current, "Assets", "really-long-line.txt");
+            var longLine = await File.ReadAllTextAsync(longLineFile);
+
+            _file = Path.Combine(current, TempPsvName);
+            _expected = CreateExpected(longLine);
+
+            await CreateFile(_file, _expected);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            DeleteFile(_file);
+        }
+
+        [TestMethod]
+        public async Task ShouldReturnVideogames()
+        {
+            // Arrange
+            var fileParserSpansAndPipes = new FileParserSpansAndPipelines();
+
+            // Act
+            var videogames = await fileParserSpansAndPipes.Parse(_file);
+
+            // Assert
+            CollectionAssert.AreEqual(_expected, videogames, new RecursiveComparer());
+        }
+
+        private Videogame[] CreateExpected(string longLine) => new[]
+        {
+            new Videogame
+            {
+                Id = Guid.Parse("385562C2-00E0-4B45-8A99-0B54E0BC9299"),
+                Name = longLine,
+                Genre = Genres.Action,
+                ReleaseDate = new DateTime(2010, 1, 1),
+                Rating = 50,
+                HasMultiplayer = false
+            },
+            new Videogame
+            {
+                Id = Guid.Parse("385562C2-00E0-4B45-8A99-0B54E0BC9299"),
+                Name = "Another test name",
+                Genre = Genres.Adventure,
+                ReleaseDate = new DateTime(2015, 10, 10),
+                Rating = 40,
+                HasMultiplayer = true
+            },
+        };
+
+        private async Task CreateFile(string file, IEnumerable<Videogame> videogames)
+        {
+            var content = new StringBuilder();
+            foreach (var videogame in videogames)
+            {
+                content.Append($"{videogame}\n");
+            }
+
+            await File.WriteAllTextAsync(file, content.ToString());
+        }
+
+        private void DeleteFile(string file)
+        {
+            if (File.Exists(file))
+            {
+                File.Delete(file);
+            }
+        }
+    }
+}

--- a/ExploringSpansAndPipelines.Core/Parsers/FileParserSpansAndPipelines.cs
+++ b/ExploringSpansAndPipelines.Core/Parsers/FileParserSpansAndPipelines.cs
@@ -12,6 +12,8 @@ namespace ExploringSpansAndIOPipelines.Core.Parsers
 {
     public class FileParserSpansAndPipelines : IFileParser
     {
+        private const int LengthLimit = 256;
+        
         public async Task<List<Videogame>> Parse(string file)
         {
             var result = new List<Videogame>();
@@ -61,12 +63,14 @@ namespace ExploringSpansAndIOPipelines.Core.Parsers
             {
                 return Parse(sequence.FirstSpan);
             }
+
+            var length = (int) sequence.Length;
+            if (length > LengthLimit)
+            {
+                throw new ArgumentException($"Line has a length exceeding the limit: {length}");
+            }
             
-#if DEBUG
-            Span<byte> span = new byte[sequence.Length];
-#else 
-            Span<byte> span = stackalloc byte[(int)sequence.Length];
-#endif
+            Span<byte> span = stackalloc byte[length];
             sequence.CopyTo(span);
 
             return Parse(span);
@@ -74,11 +78,7 @@ namespace ExploringSpansAndIOPipelines.Core.Parsers
 
         private static Videogame Parse(ReadOnlySpan<byte> bytes)
         {
-#if DEBUG
-            Span<char> chars = new char[bytes.Length];
-#else
             Span<char> chars = stackalloc char[bytes.Length];
-#endif
             Encoding.UTF8.GetChars(bytes, chars);
                 
             return LineParserSpans.Parse(chars);


### PR DESCRIPTION
David Fowler has [pointed](https://github.com/timiskhakov/ExploringSpansAndPipelines/issues/1) to a possible stack overflow issue in `FileParserSpansAndPipelines` if the line is too long:
```csharp
Span<byte> span = stackalloc byte[(int)sequence.Length];
```
Managed to reproduce it in a test. As a workaround I introduced a failure if the line length is more than 256 chars.